### PR TITLE
Change checking default value for Source parameter

### DIFF
--- a/DSCResources/MSFT_xDismFeature/MSFT_xDismFeature.psm1
+++ b/DSCResources/MSFT_xDismFeature/MSFT_xDismFeature.psm1
@@ -50,7 +50,7 @@ function Set-TargetResource
 
         [parameter(Mandatory = $false)]
         [System.String]
-        $Source = $null
+        $Source
     )
 
     switch($Ensure)
@@ -60,7 +60,7 @@ function Set-TargetResource
             $dismParameters = @("/Online", "/Enable-Feature", "/FeatureName:$Name", "/Quiet", "/NoRestart")
 
             # Include sources directory if present
-            if ($Source -ne $null)
+            if ($Source)
             {
                 Write-Verbose "Source location set: ${Source}"
 


### PR DESCRIPTION
When $Source parameter is not passed then this parameter has "" value. Condition if ($Source -ne $null) is working incorrectly and adding "/Source:" and "/LimitAccess". Windows feature isn't install when dism.exe is running with parameter "/Source:"

My change solve this problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdismfeature/10)
<!-- Reviewable:end -->
